### PR TITLE
Update AdaptiveTableCell.cs

### DIFF
--- a/Library/AdaptiveCards/AdaptiveTableCell.cs
+++ b/Library/AdaptiveCards/AdaptiveTableCell.cs
@@ -16,5 +16,11 @@ namespace AdaptiveCards
     {
         /// <inheritdoc />
         public new const string TypeName = "TableCell";
+
+        /// <inheritdoc />
+#if !NETSTANDARD1_3
+        [XmlIgnore]
+#endif
+        public override string Type { get; set; } = TypeName;
     }
 }


### PR DESCRIPTION
Fix so serialization doesn't set AdaptiveTableCell to "Container" but rather "TableCell"